### PR TITLE
Fixes bug with parsing of environment variables and headers into context

### DIFF
--- a/fdk.go
+++ b/fdk.go
@@ -197,7 +197,7 @@ func buildConfig() map[string]string {
 	cfg := make(map[string]string, len(base))
 
 	for _, e := range os.Environ() {
-		vs := strings.SplitN(e, "=", 1)
+		vs := strings.SplitN(e, "=", 2)
 		if len(vs) < 2 {
 			vs = append(vs, "")
 		}
@@ -211,7 +211,7 @@ func buildHeadersFromEnv() http.Header {
 	hdr := make(http.Header, len(env)-len(base))
 
 	for _, e := range env {
-		vs := strings.SplitN(e, "=", 1)
+		vs := strings.SplitN(e, "=", 2)
 		if !header(vs[0]) {
 			continue
 		}


### PR DESCRIPTION
There is a bug in the way we parse environment variables and headers into `fdk.Context(ctx)`. Currently the string _key=value_ makes up the key and the value is empty.