### PR TITLE
Replace stdout with stderr to avoid corrupting FDK output on fmt.Print

### DIFF
--- a/fdk.go
+++ b/fdk.go
@@ -69,6 +69,12 @@ func WriteStatus(out io.Writer, status int) {
 // through main() in a user's function and can handle communication between the
 // function and fn server via any of the supported formats.
 func Handle(handler Handler) {
+	// temporarily redirect Stdout to Stderr so that standard print calls
+	// don't interfere with output
+	origStdout := os.Stdout
+	os.Stdout = os.Stderr
+	defer func() { os.Stdout = origStdout }()
+
 	format, _ := os.LookupEnv("FN_FORMAT")
 	do(handler, format, os.Stdin, os.Stdout)
 }


### PR DESCRIPTION
If the user's function or any of its dependencies prints to the container's stdout (e.g. via a _fmt.Println_) , this will result in the function result being corrupted. The Java FDK for instance temporarily replaces stdout with stderr to avoid this issue, replacing the original stdout once the function handler has been invoked. This also makes it easier to migrate functions developed for other platforms (e.g. fission), where developers tend to print to stdout for debugging purposes.

Alternatively, we could provide a log interface in the function handler's ctx to facilitate printing to stderr. 