### PR TITLE
Respond to changes to JSON format

### DIFF
--- a/fdk_test.go
+++ b/fdk_test.go
@@ -75,8 +75,10 @@ func TestJSON(t *testing.T) {
 		`{"name":"john"}`,
 		"application/json",
 		"someid",
+		"2018-01-30T16:52:39.786Z",
+		"sync",
 		callRequestHTTP{
-			Type:       "json",
+			Type:       "http",
 			RequestURL: "someURL",
 			Headers:    http.Header{},
 		},
@@ -145,6 +147,8 @@ func TestJSONOverwriteStatusCodeAndHeaders(t *testing.T) {
 		`{"name":"john"}`,
 		"application/json",
 		"someid",
+		"2018-01-30T16:52:39.786Z",
+		"sync",
 		callRequestHTTP{
 			Type:       "json",
 			RequestURL: "someURL",


### PR DESCRIPTION
Closes #11 .

This change responds to changes in the Fn JSON format: new fields are added and parsed, and the deadline is stored in one of those. As the deadline is no longer always in a header, the three different formats now extract it in different ways.