### PR TITLE
add content-length header, fixup hello

### DIFF
--- a/examples/hello/Dockerfile
+++ b/examples/hello/Dockerfile
@@ -1,9 +1,14 @@
-FROM fnproject/go:dev as build-stage
+# build stage
+FROM golang:1.9-alpine AS build-env
+RUN apk --no-cache add git
+ENV D=/go/src/github.com/fnproject/
+RUN go get -u github.com/golang/dep/cmd/dep
+ADD . $D
+RUN cd $D && dep ensure --vendor-only
+RUN cd $D && go build -o func && cp func /tmp/
+
+# final stage
+FROM alpine
 WORKDIR /function
-ADD . /src
-RUN go get github.com/fnproject/fdk-go
-RUN cd /src && go build -o func
-FROM fnproject/go
-WORKDIR /function
-COPY --from=build-stage /src/func /function/
+COPY --from=build-env /tmp/func /function
 ENTRYPOINT ["./func"]

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -187,6 +188,8 @@ func DoHTTPOnce(handler Handler, ctx context.Context, in io.Reader, out io.Write
 		SetHeaders(ctx, req.Header)
 		handler.Serve(ctx, req.Body, &resp)
 	}
+
+	resp.Header.Set("Content-Length", strconv.Itoa(buf.Len()))
 
 	hResp := http.Response{
 		ProtoMajor:    1,


### PR DESCRIPTION
* hello image now uses dep instead of go get. so that i can modify the fdk in
vendor and test it with the hello image mostly
* content-length header wasn't being set so we were chunking. we have the
content length, no need