### PR TITLE
Safer data processing for cloudevent

### DIFF
--- a/utils/cloudevent.go
+++ b/utils/cloudevent.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -85,7 +84,12 @@ func DoCloudEventOnce(handler Handler, ctx context.Context, in io.Reader, out io
 		ctx, cancel := CtxWithDeadline(ctx, ceIn.Extensions.Deadline)
 		defer cancel()
 
-		handler.Serve(ctx, strings.NewReader(ceIn.Data.(string)), &resp)
+		var buf bytes.Buffer
+		err = json.NewEncoder(&buf).Encode(ceIn.Data)
+		if err != nil {
+			return err
+		}
+		handler.Serve(ctx, &buf, &resp)
 	}
 	ceOut.EventID = ceIn.EventID
 	ceOut.EventTime = time.Now()


### PR DESCRIPTION
```
cat payload.json | fn call app route
{"error":{"message":"container exit code 2"}}
ERROR: error calling function: status 502

~/workspace/cloudevents-demo master*
❯ fn logs g cloudevents last
panic: interface conversion: interface {} is map[string]interface {}, not string

goroutine 1 [running]:
func/vendor/github.com/fnproject/fdk-go/utils.DoCloudEventOnce(0x7f86bdad2fd0, 0x6ad9c8, 0x6ced40, 0xc420074d50, 0x6cc7c0, 0xc42000e010, 0x6cc7e0, 0xc42000e018, 0xc420104000, 0xc420074d80, ...)
    /go/src/func/vendor/github.com/fnproject/fdk-go/utils/cloudevent.go:88 +0x6b9
func/vendor/github.com/fnproject/fdk-go/utils.DoCloudEvent(0x7f86bdad2fd0, 0x6ad9c8, 0x6ced40, 0xc420074d50, 0x6cc7c0, 0xc42000e010, 0x6cc7e0, 0xc42000e018)
    /go/src/func/vendor/github.com/fnproject/fdk-go/utils/cloudevent.go:102 +0xd9
func/vendor/github.com/fnproject/fdk-go/utils.Do(0x7f86bdad2fd0, 0x6ad9c8, 0xc42001606a, 0xa, 0x6cc7c0, 0xc42000e010, 0x6cc7e0, 0xc42000e018)
    /go/src/func/vendor/github.com/fnproject/fdk-go/utils/utils.go:47 +0x1f6
func/vendor/github.com/fnproject/fdk-go.Handle(0x6ccc60, 0x6ad9c8)
    /go/src/func/vendor/github.com/fnproject/fdk-go/fdk.go:81 +0xce
main.main()
    /go/src/func/func.go:20 +0x39
```
but works fine for cURL