### PR TITLE
json values are people too

### DIFF
--- a/utils/cloudevent.go
+++ b/utils/cloudevent.go
@@ -86,8 +86,8 @@ func DoCloudEventOnce(handler Handler, ctx context.Context, in io.Reader, out io
 		defer cancel()
 
 		if ceIn.ContentType == "application/json" {
-			data := ceIn.Data.(map[string]interface{})
-			err = json.NewEncoder(buf).Encode(data)
+			// TODO this is lame, need to make FDK cloud event native and not io.Reader
+			err = json.NewEncoder(buf).Encode(ceIn.Data)
 			in := strings.NewReader(buf.String()) // string is immutable, we need a copy
 			buf.Reset()
 			handler.Serve(ctx, in, &resp)


### PR DESCRIPTION
per https://github.com/cloudevents/spec/blob/master/json-format.md#31-special-handling-of-the-data-attribute
we are misinterpreting what a json value is according to https://tools.ietf.org/html/rfc7159#section-3 --
this is also broken in the fn server, which needs tests added (WIP)

queue up more reasons to not implement cloud events in our fdks until
we figure out how we want to use them.