### PR TITLE
chmod allow users to write to socket file

### DIFF
--- a/examples/hello/Gopkg.lock
+++ b/examples/hello/Gopkg.lock
@@ -2,16 +2,17 @@
 
 
 [[projects]]
+  branch = "master"
   name = "github.com/fnproject/fdk-go"
   packages = [
     ".",
     "utils"
   ]
-  revision = "b7dbe300389ea75640ba4a220475decf2997fae9"
+  revision = "ea2a4a610560f08c91d6a6d6f72d132900a8840a"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7c7c070b6d06492bda7cdae73b1a093369644a37bc5e1f05eaf7620d5b271e76"
+  inputs-digest = "c55f0d3da5ec2e9e5c9a7c563702e4cf28513fa1aaea1c18664ca2cb7d726f89"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/examples/hello/Gopkg.toml
+++ b/examples/hello/Gopkg.toml
@@ -21,5 +21,5 @@
 
 
 [[constraint]]
-  revision = "b7dbe300389ea75640ba4a220475decf2997fae9"
+  branch = "master"
   name = "github.com/fnproject/fdk-go"

--- a/utils/httpstream.go
+++ b/utils/httpstream.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
-	"strings"
+	"syscall"
 )
 
 type HTTPHandler struct {
@@ -32,9 +34,9 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func StartHTTPServer(handler Handler, path, format string) {
 
-	tokens := strings.Split(path, ":")
-	if len(tokens) != 2 {
-		panic("cannot process listener path: " + path)
+	uri, err := url.Parse(path)
+	if err != nil {
+		log.Fatalln("url parse error: ", path, err)
 	}
 
 	server := http.Server{
@@ -44,17 +46,20 @@ func StartHTTPServer(handler Handler, path, format string) {
 	}
 
 	// try to remove pre-existing UDS: ignore errors here
-	if tokens[0] == "unix" {
-		os.Remove(tokens[1])
+	if uri.Scheme == "unix" {
+		os.Remove(uri.Path)
+
+		// this will give user perms to write to the sock file
+		syscall.Umask(0000)
 	}
 
-	listener, err := net.Listen(tokens[0], tokens[1])
+	listener, err := net.Listen(uri.Scheme, uri.Path)
 	if err != nil {
-		panic("net.Listen error: " + err.Error())
+		log.Fatalln("net.Listen error: ", err)
 	}
 
 	err = server.Serve(listener)
 	if err != nil && err != http.ErrServerClosed {
-		panic("server.Serve error: " + err.Error())
+		log.Fatalln("serve error: ", err)
 	}
 }

--- a/utils/httpstream.go
+++ b/utils/httpstream.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 )
 
@@ -46,7 +47,7 @@ func StartHTTPServer(handler Handler, path, format string) {
 	}
 
 	// try to remove pre-existing UDS: ignore errors here
-	phonySock := "/tmp/phonyfn.sock"
+	phonySock := filepath.Dir(uri.Path) + "phony" + filepath.Base(uri.Path)
 	if uri.Scheme == "unix" {
 		os.Remove(phonySock)
 	}

--- a/utils/httpstream.go
+++ b/utils/httpstream.go
@@ -47,7 +47,7 @@ func StartHTTPServer(handler Handler, path, format string) {
 	}
 
 	// try to remove pre-existing UDS: ignore errors here
-	phonySock := filepath.Dir(uri.Path) + "phony" + filepath.Base(uri.Path)
+	phonySock := filepath.Join(filepath.Dir(uri.Path), "phony"+filepath.Base(uri.Path))
 	if uri.Scheme == "unix" {
 		os.Remove(phonySock)
 	}

--- a/utils/httpstream.go
+++ b/utils/httpstream.go
@@ -72,17 +72,10 @@ func sockPerm(phonySock, realSock string) {
 	defer runtime.UnlockOSThread()
 
 	// somehow this is the best way to get a permissioned sock file, don't ask questions, life is sad and meaningless
-	f, err := os.Create(phonySock)
+	err := os.Chmod(phonySock, 0666)
 	if err != nil {
-		log.Fatalln("error creating sock file", err)
-	}
-
-	err = f.Chmod(0666)
-	if err != nil {
-		f.Close()
 		log.Fatalln("error giving sock file a perm", err)
 	}
-	f.Close()
 
 	err = os.Symlink(realSock, phonySock)
 	if err != nil {

--- a/utils/httpstream.go
+++ b/utils/httpstream.go
@@ -72,10 +72,17 @@ func sockPerm(phonySock, realSock string) {
 	defer runtime.UnlockOSThread()
 
 	// somehow this is the best way to get a permissioned sock file, don't ask questions, life is sad and meaningless
-	err := os.Chmod(phonySock, 0666)
+	f, err := os.Create(phonySock)
 	if err != nil {
+		log.Fatalln("error creating sock file", err)
+	}
+
+	err = f.Chmod(0666)
+	if err != nil {
+		f.Close()
 		log.Fatalln("error giving sock file a perm", err)
 	}
+	f.Close()
 
 	err = os.Symlink(realSock, phonySock)
 	if err != nil {


### PR DESCRIPTION
this seems like a bad idea. it is, however, a reasonably good idea since using
chmod will result in a race between creating the socket and setting the permissions
where fn could try to connect to it. with this, fn doesn't need to be run as
root, which we kinda need to satisfy really, and it seems a bit odd to try to
maneuver based on context of in a service or oss from the fdk level.

reset gopkg lock file (won't work until master is updated)