### PR TITLE
chmod sock file dance

### DIFF
--- a/examples/hello/Gopkg.lock
+++ b/examples/hello/Gopkg.lock
@@ -2,16 +2,17 @@
 
 
 [[projects]]
+  branch = "master"
   name = "github.com/fnproject/fdk-go"
   packages = [
     ".",
     "utils"
   ]
-  revision = "b7dbe300389ea75640ba4a220475decf2997fae9"
+  revision = "ea2a4a610560f08c91d6a6d6f72d132900a8840a"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7c7c070b6d06492bda7cdae73b1a093369644a37bc5e1f05eaf7620d5b271e76"
+  inputs-digest = "c55f0d3da5ec2e9e5c9a7c563702e4cf28513fa1aaea1c18664ca2cb7d726f89"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/examples/hello/Gopkg.toml
+++ b/examples/hello/Gopkg.toml
@@ -21,5 +21,5 @@
 
 
 [[constraint]]
-  revision = "b7dbe300389ea75640ba4a220475decf2997fae9"
+  branch = "master"
   name = "github.com/fnproject/fdk-go"


### PR DESCRIPTION
in order for fn to work without root, we must set permissions on the sock file
we create to allow users to write to the sock file. since go creates the file
in bind, we have to bind to a not-the-real sock file and hard link that file
to the real sock file, which will send an inotify event to fn to start sending
in tasks. voila. soft link didn't play nice.

the successor to #31 that seems to work - turns out if you rebase and the PR is open it's cool, but if it's closed you have to make another one. trolls.