### PR TITLE
decap/encap http-stream headers

### DIFF
--- a/examples/hello/func.go
+++ b/examples/hello/func.go
@@ -22,6 +22,8 @@ func myHandler(ctx context.Context, in io.Reader, out io.Writer) {
 		person.Name = "World"
 	}
 
+	fdk.SetHeader(out, "Content-Type", "application/json")
+
 	msg := struct {
 		Msg string `json:"message"`
 	}{

--- a/utils/httpstream.go
+++ b/utils/httpstream.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -8,29 +11,101 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
+	"sync"
 )
+
+// in case we go over the timeout, need to use a pool since prev buffer may not be freed
+var bufPool = &sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
 
 type HTTPHandler struct {
 	handler Handler
 }
 
 func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	buf := bufPool.Get().(*bytes.Buffer)
+	defer bufPool.Put(buf)
+
+	resp := Response{
+		Writer: buf,
+		Status: 200,
+		Header: make(http.Header), // XXX(reed): pool these too
+	}
+
 	ctx := WithContext(r.Context(), &Ctx{
 		Config: BuildConfig(),
 	})
 
-	fnDeadline := Context(ctx).Header.Get("FN_DEADLINE")
-	ctx, cancel := CtxWithDeadline(ctx, fnDeadline)
+	ctx, cancel := decapHeaders(ctx, r)
 	defer cancel()
 
-	SetHeaders(ctx, r.Header)
-	SetRequestURL(ctx, r.URL.String())
-	SetMethod(ctx, r.Method)
-	h.handler.Serve(ctx, r.Body, w)
+	h.handler.Serve(ctx, r.Body, &resp)
 
-	// TODO can we get away with no buffer? set content length is 'nice' but they
-	// can do it if they really need to... i lack ideas, now that we have a real
-	// resp writer tho it's really worth considering.
+	encapHeaders(w, resp)
+
+	// XXX(reed): 504 if ctx is past due / handle errors with 5xx? just 200 for now
+	// copy response from user back up now with headers in place...
+	io.Copy(w, buf)
+
+	// XXX(reed): handle streaming, we have to intercept headers but not necessarily body (ie no buffer)
+}
+
+func encapHeaders(fn http.ResponseWriter, user Response) {
+	fnh := fn.Header()
+	fnh.Set("Fn-Http-Status", strconv.Itoa(user.Status))
+
+	for k, vs := range user.Header {
+		switch k {
+		case "Content-Type":
+			// don't modify this one...
+		default:
+			// prepend this guy
+			k = "Fn-Http-H-" + k
+		}
+
+		for _, v := range vs {
+			fnh.Add(k, v)
+		}
+	}
+}
+
+// TODO can make this the primary means of context construction
+func decapHeaders(ctx context.Context, r *http.Request) (_ context.Context, cancel func()) {
+	// XXX(reed): could make a new header bucket to dump things into instead of futzing
+
+	rctx := Context(ctx)
+	var deadline string
+
+	for k, vs := range r.Header {
+		switch k {
+		// XXX(reed): we should strip out request url and method too but for invoke they don't exist...
+		case "Fn-Deadline":
+			r.Header.Del(k)
+			deadline = vs[0]
+		case "Fn-Call-Id":
+			r.Header.Del(k)
+			rctx.callId = vs[0]
+		case "Content-Type":
+			// just leave this one instead of deleting
+		default:
+			continue
+		}
+
+		if !strings.HasPrefix(k, "Fn-Http-H-") {
+			// XXX(reed): we need 2 header buckets on ctx, one for these and one for the 'original req' headers
+			// for now just nuke so the headers are clean...
+			r.Header.Del(k)
+			continue
+		}
+
+		r.Header.Del(k)
+		for _, v := range vs {
+			r.Header.Add(strings.TrimPrefix(k, "Fn-Http-H-"), v)
+		}
+	}
+
+	return CtxWithDeadline(ctx, deadline)
 }
 
 func StartHTTPServer(handler Handler, path, format string) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -30,7 +30,14 @@ type Ctx struct {
 	Config     map[string]string
 	RequestURL string
 	Method     string
+
+	// XXX(reed): we should get req url / method out and rebuild the actual request too?
+	// XXX(reed): we should change go fdk handler to http.Handler instead of fdk handler fo real
+	// XXX(reed): should strip out eg FN_APP_NAME, etc as fields so Config is actually the config not config + fn's env vars
+	callId string
 }
+
+func (c Ctx) CallId() string { return c.callId }
 
 type key struct{}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -26,13 +26,19 @@ func WithContext(ctx context.Context, fnctx *Ctx) context.Context {
 
 // Ctx provides access to Config and Headers from fn.
 type Ctx struct {
-	Header     http.Header
+	// Header are the unmodified headers as sent to the container, see
+	// HTTPHeader for specific trigger headers
+	Header http.Header
+
+	// HTTPHeader are the request headers as they appear on the original HTTP request,
+	// for an http trigger.
+	HTTPHeader http.Header
 	Config     map[string]string
 	RequestURL string
 	Method     string
 
-	// XXX(reed): we should get req url / method out and rebuild the actual request too?
-	// XXX(reed): we should change go fdk handler to http.Handler instead of fdk handler fo real
+	// XXX(reed): should turn this whole mess into some kind of event that we can
+	// morph into another type of an event after http/json/default die
 	// XXX(reed): should strip out eg FN_APP_NAME, etc as fields so Config is actually the config not config + fn's env vars
 	callId string
 }


### PR DESCRIPTION
pursuant to 'the contract' this rips off Fn* prefixed headers, and adds some
back at the end. the fdk here could use some cleaning up now that we have just
this format to worry about, this should handle things for now though

original request headers will be available in the context header bucket, and
nothing else. this means invokes http headers aren't passed down (at long last)