### PR TITLE
Preserve stderr output from init image commands, as it helps with debugging.

### DIFF
--- a/images/init/boilerplate/mod.sh
+++ b/images/init/boilerplate/mod.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -euo pipefail
-go mod init "$FN_FUNCTION_NAME" > /tmp/go_mod_output 2>&1
-go get > /tmp/go_get_output 2>&1
+
+# Pipe stdout to file, as Fn CLI init-image reads stdout to untar (outputting messages to stderr is fine).
+go mod init "$FN_FUNCTION_NAME" > /tmp/go_mod_output
+go get > /tmp/go_get_output
+
 tar c go.mod func.go func.init.yaml


### PR DESCRIPTION
Preserve `stderr` output from init image commands, as it helps with debugging. Fn CLI only untars `stdout`, and will display `stderr` to the user upon non-zero exit of the docker run of the init-image.

Testing (with current `master` branch of CLI):

```
$ fn init --init-image fdk-go-init:latest tmp 
Creating function at: ./tmp
Building from init-image: fdk-go-init:latest
func.yaml created.

$ ls tmp
func.go   func.yaml go.mod
```