### PR TITLE
Ensure release script actually bumps version.go

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -23,4 +23,5 @@ echo "Version: $version"
 git add -u
 git commit -m "v$version release [skip ci]"
 git tag -f -a "v$version" -m "version v$version"
+git push
 git push --tags origin master

--- a/version.go
+++ b/version.go
@@ -3,6 +3,6 @@ package fdk
 import "fmt"
 
 // Version is the FDK version
-const Version = "0.0.0"
+const Version = "0.0.1"
 
 var versionHeader = fmt.Sprintf("fdk-go/%s", Version)


### PR DESCRIPTION
The release script needs to push the version bump change it makes to version.go - master is currently failing because we're trying to push tags for a version that already exists. This also bumps current contents of version.go so that is in line with the tags/releases that already exist.