### PR TITLE
Add log statements for every request

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -39,6 +39,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	logFrameHeader(r)
+	log.Println("Request started")
 
 	h.handler.Serve(ctx, r.Body, &resp)
 
@@ -59,6 +60,8 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// XXX(reed): 504 if ctx is past due / handle errors with 5xx? just 200 for now
 	// copy response from user back up now with headers in place...
 	io.Copy(w, buf)
+
+	log.Println("Request completed")
 
 	// XXX(reed): handle streaming, we have to intercept headers but not necessarily body (ie no buffer)
 }

--- a/images/init/boilerplate/func.go
+++ b/images/init/boilerplate/func.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 
 	fdk "github.com/fnproject/fdk-go"
 )
@@ -25,5 +26,6 @@ func myHandler(ctx context.Context, in io.Reader, out io.Writer) {
 	}{
 		Msg: fmt.Sprintf("Hello %s", p.Name),
 	}
+	log.Print("Inside Go Hello World function")
 	json.NewEncoder(out).Encode(&msg)
 }


### PR DESCRIPTION
 * FDK should log before and after a call completes. This is achieved by adding log lines to handleRequest.
 * The boilerplate code in the init image should have a log message printed to serve as an example.