### PR TITLE
Releasing version v0.0.8

### DIFF
--- a/fdk_test.go
+++ b/fdk_test.go
@@ -132,6 +132,14 @@ func TestHTTPStreamSock(t *testing.T) {
 		t.Fatal("got wrong status code:", res.StatusCode)
 	}
 
+	if res.Header.Get("Fn-Fdk-Version") != versionHeader {
+		t.Errorf("Expected \"%s\" but got \"%s\"", versionHeader, res.Header.Get("Fn-Fdk-Version"))
+	}
+
+	if res.Header.Get("Fn-Fdk-Runtime") != runtimeHeader {
+		t.Errorf("Expected \"%s\" but got \"%s\"", runtimeHeader, res.Header.Get("Fn-Fdk-Runtime"))
+	}
+
 	outBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal(err)

--- a/handler.go
+++ b/handler.go
@@ -71,6 +71,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// send back our version
 	w.Header().Set("Fn-Fdk-Version", versionHeader)
+	w.Header().Set("Fn-Fdk-Runtime", runtimeHeader)
 
 	// XXX(reed): 504 if ctx is past due / handle errors with 5xx? just 200 for now
 	// copy response from user back up now with headers in place...

--- a/version.go
+++ b/version.go
@@ -16,9 +16,14 @@
 
 package fdk
 
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
 
 // Version is the FDK version
-const Version = "0.0.7"
+const Version = "0.0.8"
 
 var versionHeader = fmt.Sprintf("fdk-go/%s", Version)
+var runtimeHeader = fmt.Sprintf("go/%s", strings.TrimLeft(runtime.Version(), "go"))


### PR DESCRIPTION
Started tracking Go runtime version in Fn-Fdk-Runtime header as go/x.y.z format.